### PR TITLE
fix sublime.setting.get return None

### DIFF
--- a/sublime_tfs.py
+++ b/sublime_tfs.py
@@ -395,5 +395,7 @@ class TfsQueryCredentialsCommand(sublime_plugin.WindowCommand):
         credentials.password = s
 
 # ------------------------------------------------------------
-credentials = TfsCredentials()
+def plugin_loaded():
+    global credentials
+    credentials = TfsCredentials()
 # ------------------------------------------------------------


### PR DESCRIPTION
I find that when initializing `TfsCredentials`, I still get `tfs_username` None even though the value is set in the `sublime_tfs.sublime-settings`. Sublime document provides the function  `plugin_loaded` will be called when the API is ready to use. 